### PR TITLE
add more options to Robot constructor

### DIFF
--- a/@Robot/Robot.m
+++ b/@Robot/Robot.m
@@ -25,10 +25,16 @@ classdef Robot
     end
     
     methods
-        function robot = Robot(realNameRobot, start_path, codyco_folder, yarpWBIfile)
+        function robot = Robot(realNameRobot, start_path, codyco_folder, yarpWBIfile, build_directory)
             if ~exist('yarpWBIfile','var')
                 yarpWBIfile = 'yarpWholeBodyInterface.ini';
             end
+            if ~exist('build_directory','var')
+                robot.build_folder = 'build';
+            else
+                robot.build_folder = build_directory;
+            end
+
             % Name robot
             robot.realNameRobot = realNameRobot;
             % Start path

--- a/dump_joints.m
+++ b/dump_joints.m
@@ -7,7 +7,11 @@
 % - Name of robot
 % - folder where you want save the data
 % - codyco-superbuild folder (try to put "getenv('CODYCO_SUPERBUILD_ROOT')" )
-robot = Robot('iCubGenova04', 'experiments', '/Users/Raffaello/iit/codyco-superbuild');
+% - optional: name of the yarpWholeBodyInterface configuration file.
+%              Default: yarpWholeBodyInterface.ini 
+% - optional: name of the build directory 
+%              Default: build 
+robot = Robot('iCubGenova01', 'experiments', '/usr/local/src/robot/codyco-superbuild');
 % Setup robot configuration:
 % Variables:
 % - worldRefFrame
@@ -17,8 +21,8 @@ robot = robot.setReferenceFrame('root_link','true');
 %% Add motors to test
 robot.joints = [robot.joints robot.getJoint('l_hip_roll')];
 robot.joints = [robot.joints robot.getJoint('l_hip_yaw')];
-robot.joints = [robot.joints robot.getCoupledJoints('torso')];
-robot.joints = [robot.joints robot.getCoupledJoints('l_shoulder')];
+% robot.joints = [robot.joints robot.getCoupledJoints('torso')];
+% robot.joints = [robot.joints robot.getCoupledJoints('l_shoulder')];
 
 %% Configure your computer
 % Set all variables:


### PR DESCRIPTION
Not all the setups name the build directory `build`. For example it is a policy for icub shared sources to have the build directory named `build-x86_64'. 
